### PR TITLE
WIP: proposal for a way to configure dimmer colors (hooks part) [skip ci]

### DIFF
--- a/app/views/install.scala.txt
+++ b/app/views/install.scala.txt
@@ -229,6 +229,7 @@ echo "sdkman_curl_max_time=10" >> "$sdkman_config_file"
 echo "sdkman_beta_channel=false" >> "$sdkman_config_file"
 echo "sdkman_debug_mode=false" >> "$sdkman_config_file"
 echo "sdkman_colour_enable=true" >> "$sdkman_config_file"
+echo "sdkman_colour_style=light # light/dark" >> "$sdkman_config_file"
 
 echo "Download script archive..."
 curl -L "${SDKMAN_SERVICE}/broker/download/sdkman/install/${SDKMAN_VERSION}/${SDKMAN_PLATFORM}" > "$sdkman_zip_file"

--- a/app/views/selfupdate.scala.txt
+++ b/app/views/selfupdate.scala.txt
@@ -185,6 +185,10 @@ if [[ -z $(cat ${sdkman_config_file} | grep 'sdkman_colour_enable') ]]; then
 	echo "sdkman_colour_enable=true" >> "$sdkman_config_file"
 fi
 
+if [[ -z $(cat ${sdkman_config_file} | grep 'sdkman_colour_style') ]]; then
+	echo "sdkman_colour_style=light # light/dark" >> "$sdkman_config_file"
+fi
+
 
 # drop version token
 echo "$SDKMAN_VERSION" > "${SDKMAN_DIR}/var/version"


### PR DESCRIPTION
Completes the sdkman/sdkman-cli#600 pull request proposing the introduction of the sdkman_colour_style configuration variable. Here we update the hooks to generate the variable in the configuration files.
The line added is in the form

sdkman_colour_style=light # light/dark
i.e including a minimal comment with the values to be used.  
CI skipped.