### PR TITLE
Suggest fish users to install sdkman-for-fish

### DIFF
--- a/app/views/install.scala.txt
+++ b/app/views/install.scala.txt
@@ -289,15 +289,19 @@ fi
 if [[ -d "${HOME}"/.config/fish && ! -f "${HOME}"/.config/fish/conf.d/sdk.fish ]]; then
     echo "It seems you have fish installed. Unfortunately, SDKMAN! does not work with fish out of the box."
     echo "Install third-party support now? [y/N/?]"
+    # prompt
 
-    # ? --> show what will be installed (necessary?)
+    while [[ ? ]];  do
+    	# show what will be installed (necessary?)
+	# reprompt
+    done
 
     if [[ y ]]; then
         if [[ ! -f "${HOME}"/.config/fish/functions/fisher.fish ]]; then
             curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs https://git.io/fisher
         fi
 
-        fisher reitzig/sdkman-for-fish
+        fish -c "fisher reitzig/sdkman-for-fish"
     fi
 fi
 

--- a/app/views/install.scala.txt
+++ b/app/views/install.scala.txt
@@ -288,21 +288,42 @@ fi
 
 if [[ -d "${HOME}"/.config/fish && ! -f "${HOME}"/.config/fish/conf.d/sdk.fish ]]; then
     echo "It seems you have fish installed. Unfortunately, SDKMAN! does not work with fish out of the box."
-    echo "Install third-party support now? [y/N/?]"
-    # prompt
+    
+    while true; do
+        read -p "Install third-party support (fisher, sdkman-for-fish) now? [yN]: " yn
+        case $yn in
+            [Yy]* )
+                if [[ -z ${XDG_CONFIG_HOME} ]]; then
+                    XDG_CONFIG_HOME="${HOME}/.config"
+                fi
 
-    while [[ ? ]];  do
-    	# show what will be installed (necessary?)
-	# reprompt
+                if [[ ! -f "${HOME}"/.config/fish/functions/fisher.fish ]]; then
+                    mkdir -p "${XDG_CONFIG_HOME}"/fish/functions/
+
+                    echo -n "Downloading fisher ... "
+                    curl_out=$(curl -fsSL \
+                                -o "${XDG_CONFIG_HOME}"/fish/functions/fisher.fish \
+                                --create-dirs https://git.io/fisher 2>&1)
+
+                    if [[ ${?} -gt 0 ]]; then
+                        echo "FAILED"
+                        echo "${curl_out}"
+                        break
+                    else
+                        echo "OKAY"
+                    fi
+
+                    unset curl_out
+                fi
+
+                fish -c "fisher add reitzig/sdkman-for-fish"
+                break
+            ;;
+            * )
+            break
+            ;;
+        esac
     done
-
-    if [[ y ]]; then
-        if [[ ! -f "${HOME}"/.config/fish/functions/fisher.fish ]]; then
-            curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs https://git.io/fisher
-        fi
-
-        fish -c "fisher reitzig/sdkman-for-fish"
-    fi
 fi
 
 echo -e "\n\n\nAll done!\n\n"

--- a/app/views/install.scala.txt
+++ b/app/views/install.scala.txt
@@ -286,6 +286,21 @@ if [[ -z $(grep 'sdkman-init.sh' "$sdkman_zshrc") ]]; then
     echo "Updated existing ${sdkman_zshrc}"
 fi
 
+if [[ -d "${HOME}"/.config/fish && ! -f "${HOME}"/.config/fish/conf.d/sdk.fish ]]; then
+    echo "It seems you have fish installed. Unfortunately, SDKMAN! does not work with fish out of the box."
+    echo "Install third-party support now? [y/N/?]"
+
+    # ? --> show what will be installed (necessary?)
+
+    if [[ y ]]; then
+        if [[ ! -f "${HOME}"/.config/fish/functions/fisher.fish ]]; then
+            curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs https://git.io/fisher
+        fi
+
+        fisher reitzig/sdkman-for-fish
+    fi
+fi
+
 echo -e "\n\n\nAll done!\n\n"
 
 echo "Please open a new terminal, or run the following in the existing one:"


### PR DESCRIPTION
Posting this as a discussion starter.

Goal: In order to make SDKMAN! accessible to fish, install [sdkman-for-fish](https://github.com/reitzig/sdkman-for-fish) after the installation was otherwise successful (as an option).

 * Does not pester users without fish.
 * Does not pester users which already have an `sdk.fish` file. (Would conflict.)
 * Asks before installing.

Left to do: finish bash trickery; finalize wording.

_Note:_ 
 1. The installation method is opinionated. 
 2. reitzig/sdkman-for-fish may have to mature a bit still.