### PR TITLE
Fix portability bug in init snippet

### DIFF
--- a/app/views/install.scala.txt
+++ b/app/views/install.scala.txt
@@ -45,8 +45,8 @@ sdkman_zshrc="${HOME}/.zshrc"
 
 sdkman_init_snippet=$( cat << EOF
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
-export SDKMAN_DIR="$SDKMAN_DIR"
-[[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+export SDKMAN_DIR="$HOME/.sdkman"
+[[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
 EOF
 )
 


### PR DESCRIPTION
The problem with this two lines
```
export SDKMAN_DIR="$SDKMAN_DIR"
[[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"
```
is, that it breaks the portability of any `.bashrc` or `.zshrc` in the case, that one uses _different_ users with the same set of dotfiles.

With the fix proposed here, we get rid of this portability problem. Just search on github for `THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK` to see how many people hardcoded their dotfiles to work with a specific $HOME/user name only. The moment the user name changes it breaks their sdkman installation.