### PR TITLE
Added new OpenJDK vendor BellSoft and specific java hooks.

### DIFF
--- a/app/controllers/HooksController.scala
+++ b/app/controllers/HooksController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import domain.Candidate.{Java, Spark}
-import domain.JdkDistro.{OpenJDK, Oracle, Zulu, ZuluFX}
+import domain.JdkDistro.{BellSoft, OpenJDK, Oracle, Zulu, ZuluFX}
 import domain.Platform._
 import domain.{Candidate, Platform}
 import play.api.Logger
@@ -29,6 +29,8 @@ class HooksController extends Controller {
           //POST: Mac OSX
           case (PostHook, Java, "8", MacOSX, Oracle) =>
             Ok(views.txt.java_post_8_oracle_osx(candidate, dropSuffix(version), MacOSX))
+          case (PostHook, Java, _, MacOSX, BellSoft) =>
+            Ok(views.txt.default_post_zip(candidate, version, MacOSX))
           case (PostHook, Java, _, MacOSX, Zulu) =>
             Ok(views.txt.default_post_tarball(candidate, version, MacOSX))
           case (PostHook, Java, _, MacOSX, ZuluFX) =>

--- a/app/domain/domain.scala
+++ b/app/domain/domain.scala
@@ -40,6 +40,7 @@ object Platform {
 object JdkDistro {
   val AdoptOpenJDK = "adpt"
   val Amazon = "amzn"
+  val BellSoft = "librca"
   val GraalVM = "grl"
   val OpenJDK = "open"
   val Oracle = "oracle"

--- a/features/java_linux_hooks.feature
+++ b/features/java_linux_hooks.feature
@@ -59,3 +59,21 @@ Feature: Java Linux Hooks
     When a hook is requested at /hooks/post/java/11.0.2-sapmchn/linux
     Then a 200 status code is received
     And the response script contains "Post Hook: linux-java-tarball"
+
+  # BellSoft
+
+  Scenario: Install BellSoft OpenJDK 8 on Linux
+    When a hook is requested at /hooks/post/java/8.0.202-librca/linux
+    Then a 200 status code is received
+    And the response script contains "Post Hook: linux-java-tarball"
+
+  Scenario: Install BellSoft OpenJDK 11 on Linux
+    When a hook is requested at /hooks/post/java/11.0.2-librca/linux
+    Then a 200 status code is received
+    And the response script contains "Post Hook: linux-java-tarball"
+
+  Scenario: Install BellSoft OpenJDK 12 on Linux
+    When a hook is requested at /hooks/post/java/12.0.0-librca/linux
+    Then a 200 status code is received
+    And the response script contains "Post Hook: linux-java-tarball"
+ 

--- a/features/java_osx_hooks.feature
+++ b/features/java_osx_hooks.feature
@@ -96,3 +96,21 @@ Feature: Java OSX Hooks
     When a hook is requested at /hooks/post/java/11.0.2-sapmchn/darwin
     Then a 200 status code is received
     And I receive a hook containing text: Post Hook: osx-java-tarball
+
+  # BellSoft
+
+  Scenario: Install BellSoft OpenJDK 8 on OSX
+    When a hook is requested at /hooks/post/java/8.0.202-librca/darwin
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+
+  Scenario: Install BellSoft OpenJDK 11 on OSX
+    When a hook is requested at /hooks/post/java/11.0.2-librca/darwin
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+
+  Scenario: Install BellSoft OpenJDK 12 on OSX
+    When a hook is requested at /hooks/post/java/12.0.0-librca/darwin
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+

--- a/features/java_windows_hooks.feature
+++ b/features/java_windows_hooks.feature
@@ -138,3 +138,35 @@ Feature: Java Windows Post Hooks
     When a hook is requested at /hooks/post/java/11.0.2-sapmchn/mingw64_nt-10.0
     Then a 200 status code is received
     And I receive a hook containing text: Post Hook: default-zip
+
+  # BellSoft
+
+  Scenario: Install BellSoft OpenJDK 8 on Cygwin Post Hook
+    When a hook is requested at /hooks/post/java/8.0.202-librca/cygwin
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+
+  Scenario: Install BellSoft OpenJDK 8 on MinGW Post Hook
+    When a hook is requested at /hooks/post/java/8.0.202-librca/mingw64_nt-10.0
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+
+  Scenario: Install BellSoft OpenJDK 11 on Cygwin Post Hook
+    When a hook is requested at /hooks/post/java/11.0.2-librca/cygwin
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+
+  Scenario: Install BellSoft OpenJDK 11 on MinGW Post Hook
+    When a hook is requested at /hooks/post/java/11.0.2-librca/mingw64_nt-10.0
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+
+  Scenario: Install BellSoft OpenJDK 12 on Cygwin Post Hook
+    When a hook is requested at /hooks/post/java/12.0.0-librca/cygwin
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip
+
+  Scenario: Install BellSoft OpenJDK 12 on MinGW Post Hook
+    When a hook is requested at /hooks/post/java/12.0.0-librca/mingw64_nt-10.0
+    Then a 200 status code is received
+    And I receive a hook containing text: Post Hook: default-zip


### PR DESCRIPTION
1. Added new vendor Bellsoft and new OpenJDK distro 'librca', a shorthand for Liberica. 
2. Changed the post install hook to default-zip for Java/BellSoft/MacOSX since we distribute ZIP files for MacOSX platform.