### PR TITLE
Use the existing bash init file in Darwin to avoid accidentally overriding existing config

### DIFF
--- a/app/views/install.scala.txt
+++ b/app/views/install.scala.txt
@@ -39,6 +39,7 @@ sdkman_archives_folder="${SDKMAN_DIR}/archives"
 sdkman_candidates_folder="${SDKMAN_DIR}/candidates"
 sdkman_config_file="${sdkman_etc_folder}/config"
 sdkman_bash_profile="${HOME}/.bash_profile"
+sdkman_bash_login="${HOME}/.bash_login"
 sdkman_profile="${HOME}/.profile"
 sdkman_bashrc="${HOME}/.bashrc"
 sdkman_zshrc="${HOME}/.zshrc"
@@ -266,11 +267,22 @@ echo "$SDKMAN_VERSION" > "${SDKMAN_DIR}/var/version"
 
 
 if [[ $darwin == true ]]; then
-  touch "$sdkman_bash_profile"
+  # Bash only reads one of the following config files, in this order. Write to the one that the user is already using if possible.
+  if [[ -e "$sdkman_bash_profile" ]]; then
+    sdkman_init_file="$sdkman_bash_profile"
+  elif [[ -e "$sdkman_bash_login" ]]; then
+    sdkman_init_file="$sdkman_bash_login"
+  elif [[ -e "$sdkman_profile" ]]; then
+    sdkman_init_file="$sdkman_profile"
+  else
+    # Default to creating .bash_profile as it's the least likely to be overridden in the future
+    sdkman_init_file="$sdkman_bash_profile"
+  fi
+  touch "$sdkman_init_file"
   echo "Attempt update of login bash profile on OSX..."
-  if [[ -z $(grep 'sdkman-init.sh' "$sdkman_bash_profile") ]]; then
-    echo -e "\n$sdkman_init_snippet" >> "$sdkman_bash_profile"
-    echo "Added sdkman init snippet to $sdkman_bash_profile"
+  if [[ -z $(grep 'sdkman-init.sh' "$sdkman_init_file") ]]; then
+    echo -e "\n$sdkman_init_snippet" >> "$sdkman_init_file"
+    echo "Added sdkman init snippet to $sdkman_init_file"
   fi
 else
   echo "Attempt update of interactive bash profile on regular UNIX..."


### PR DESCRIPTION
Bash startup is weird and will only read from a single config file when an interactive login shell is started. From [the bash man page](https://linux.die.net/man/1/bash):

> When bash is invoked as an interactive login shell, or as a non-interactive shell with the --login option, it first reads and executes commands from the file /etc/profile, if that file exists. After reading that file, it looks for ~/.bash_profile, ~/.bash_login, and ~/.profile, in that order, and reads and executes commands from the first one that exists and is readable.

The old behavior of the install script was to always write to `~/.bash_profile`. If a user stored their configuration in `.bash_login` or `.profile`, the newly-created `.bash_profile` would take precedence over the existing file, causing all existing login config to be ignored.

This PR updates the install script to append our init snippet to whatever file the user is already using, only creating a new `.bash_profile` if no files already exist. 