### PR TITLE
Legacy selfupdate support

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -6,5 +6,5 @@ GET        /alive                                             controllers.Health
 GET        /install/beta                                      controllers.InstallController.install(beta: Boolean = true, rcupdate: Option[Boolean])
 GET        /install/stable                                    controllers.InstallController.install(beta: Boolean = false, rcupdate: Option[Boolean])
 GET        /selfupdate/beta                                   controllers.SelfUpdateController.selfUpdate(beta: Boolean = true)
-GET        /selfupdate/stable                                 controllers.SelfUpdateController.selfUpdate(beta: Boolean = false)
+GET        /selfupdate/stable                                 controllers.SelfUpdateController.selfUpdate(beta: Boolean ?= false)
 GET        /hooks/:phase/:candidate/:version/:platform        controllers.HooksController.hook(phase, candidate, version, platform)

--- a/features/selfupdate.feature
+++ b/features/selfupdate.feature
@@ -21,3 +21,21 @@ Feature: Selfupdate
     And the response script contains "# selfupdate:- channel: beta; version: latest+bff371f; api: https://beta.sdkman.io"
     And the response script contains "SDKMAN_VERSION="latest+bff371f""
     And the response script contains "SDKMAN_SERVICE="https://beta.sdkman.io/2""
+
+  Scenario: A selfupdate is performed on the legacy Stable Channel
+    When a request is made to the /selfupdate/stable?beta=false endpoint
+    Then a 200 status code is received
+    And a "text/plain; charset=UTF-8" content type is received
+    And the response script starts with "#!/bin/bash"
+    And the response script contains "# selfupdate:- channel: stable; version: 1.0.0; api: https://api.sdkman.io"
+    And the response script contains "SDKMAN_VERSION="1.0.0""
+    And the response script contains "SDKMAN_SERVICE="https://api.sdkman.io/2""
+
+  Scenario: A selfupdate is performed on the legacy Beta Channel
+    When a request is made to the /selfupdate/stable?beta=true endpoint
+    Then a 200 status code is received
+    And a "text/plain; charset=UTF-8" content type is received
+    And the response script starts with "#!/bin/bash"
+    And the response script contains "# selfupdate:- channel: beta; version: latest+bff371f; api: https://beta.sdkman.io"
+    And the response script contains "SDKMAN_VERSION="latest+bff371f""
+    And the response script contains "SDKMAN_SERVICE="https://beta.sdkman.io/2""


### PR DESCRIPTION
The selfupdates will now be driven by a `beta` subdomain on the URL. All selfupdates originating from this domain will be forwarded to the `/selfupdate/beta` route. All selfupdates from the `api` subdomain will be sent to the `/selfupdate/stable` route.

This PR also supports cases where legacy beta installations call the `api` subdomain, but instead use a `beta=true` query parameter. These calls will be sent to the `/selfupdate/stable` route, but will propagate the `beta` query parameter to switch on beta behaviour.