### PR TITLE
Propagate native cli version in beta channel

### DIFF
--- a/app/controllers/InstallController.scala
+++ b/app/controllers/InstallController.scala
@@ -23,8 +23,8 @@ class InstallController @Inject() (
         stableBaseUrl <- stableBaseUrlO
         betaBaseUrl   <- betaBaseUrlO
         app           <- maybeApp
-        stableVersion = app.stableCliVersion
-        betaVersion   = app.betaCliVersion
+        stableVersion       = app.stableCliVersion
+        betaVersion         = app.betaCliVersion
         stableNativeVersion = app.stableNativeCliVersion
       } yield
         if (beta) {

--- a/app/controllers/InstallController.scala
+++ b/app/controllers/InstallController.scala
@@ -25,11 +25,13 @@ class InstallController @Inject() (
         app           <- maybeApp
         stableVersion = app.stableCliVersion
         betaVersion   = app.betaCliVersion
+        stableNativeVersion = app.stableNativeCliVersion
       } yield
         if (beta) {
           Ok(
             views.txt.install_beta(
               cliVersion = betaVersion,
+              cliNativeVersion = stableNativeVersion,
               baseUrl = betaBaseUrl,
               rcUpdate = rcUpdate.getOrElse(true)
             )

--- a/app/controllers/SelfUpdateController.scala
+++ b/app/controllers/SelfUpdateController.scala
@@ -23,9 +23,9 @@ class SelfUpdateController @Inject() (
         stableBaseUrl <- stableBaseUrlO
         betaBaseUrl   <- betaBaseUrlO
         app           <- maybeApp
-        stableVersion = app.stableCliVersion
-        betaVersion   = app.betaCliVersion
-        stableNativeVersion  = app.stableNativeCliVersion
+        stableVersion       = app.stableCliVersion
+        betaVersion         = app.betaCliVersion
+        stableNativeVersion = app.stableNativeCliVersion
       } yield
         if (beta) {
           Ok(

--- a/app/controllers/SelfUpdateController.scala
+++ b/app/controllers/SelfUpdateController.scala
@@ -25,11 +25,13 @@ class SelfUpdateController @Inject() (
         app           <- maybeApp
         stableVersion = app.stableCliVersion
         betaVersion   = app.betaCliVersion
+        stableNativeVersion  = app.stableNativeCliVersion
       } yield
         if (beta) {
           Ok(
             views.txt.selfupdate_beta(
               cliVersion = betaVersion,
+              cliNativeVersion = stableNativeVersion,
               baseUrl = betaBaseUrl
             )
           )

--- a/app/domain/domain.scala
+++ b/app/domain/domain.scala
@@ -4,11 +4,11 @@ case class Candidate private (identifier: String, name: String)
 object Candidate {
   def apply(id: String): Candidate = Candidate(id, id.capitalize)
 
-  val Flink = Candidate("flink")
+  val Flink  = Candidate("flink")
   val Hadoop = Candidate("hadoop")
-  val Java  = Candidate("java")
-  val Spark = Candidate("spark")
-  val JMC   = Candidate("jmc")
+  val Java   = Candidate("java")
+  val Spark  = Candidate("spark")
+  val JMC    = Candidate("jmc")
 }
 
 case class Platform(identifier: String, name: String)
@@ -28,7 +28,8 @@ object Platform {
 
   private val WindowsMinGWPattern = "(mingw|msys).*".r
 
-  private val LinuxPattern = "(linux|linux32|linux64|linuxx32|linuxx64|linuxarm32|linuxarm64|linuxarm32sf|linuxarm32hf)".r
+  private val LinuxPattern =
+    "(linux|linux32|linux64|linuxx32|linuxx64|linuxarm32|linuxarm64|linuxarm32sf|linuxarm32hf)".r
 
   private val DarwinPattern = "(darwin|darwinx64|darwinarm64)".r
 

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -1,4 +1,4 @@
-@(cliVersion: String, baseUrl: String, rcUpdate: Boolean)#!/bin/bash
+@(cliVersion: String, cliNativeVersion: String, baseUrl: String, rcUpdate: Boolean)#!/bin/bash
 #
 #   Copyright 2017 Marco Vermeulen
 #
@@ -20,6 +20,7 @@
 # Global variables
 SDKMAN_SERVICE="@baseUrl"
 SDKMAN_VERSION="@cliVersion"
+SDKMAN_NATIVE_VERSION="@cliNativeVersion"
 SDKMAN_PLATFORM=$(uname)
 
 if [ -z "$SDKMAN_DIR" ]; then
@@ -270,6 +271,9 @@ rm -rf "$sdkman_zip_base_folder"
 
 echo "Set version to $SDKMAN_VERSION ..."
 echo "$SDKMAN_VERSION" > "${SDKMAN_DIR}/var/version"
+
+echo "Set native version to $SDKMAN_NATIVE_VERSION ..."
+echo "$SDKMAN_NATIVE_VERSION" > "${SDKMAN_DIR}/var/version_native"
 
 @if(rcUpdate) {
 if [[ $darwin == true ]]; then

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -1,5 +1,5 @@
 @import java.time.LocalDate
-@(cliVersion: String, baseUrl: String)#!/bin/bash
+@(cliVersion: String, cliNativeVersion: String, baseUrl: String)#!/bin/bash
 #
 #   Copyright 2017 Marco Vermeulen
 #
@@ -21,6 +21,7 @@
 # Global variables
 SDKMAN_SERVICE="@baseUrl"
 SDKMAN_VERSION="@cliVersion"
+SDKMAN_NATIVE_VERSION="@cliNativeVersion"
 SDKMAN_PLATFORM=$(uname)
 
 # OS specific support (must be 'true' or 'false').
@@ -183,6 +184,7 @@ fi
 
 # drop version token
 echo "$SDKMAN_VERSION" > "${SDKMAN_DIR}/var/version"
+echo "$SDKMAN_NATIVE_VERSION" > "${SDKMAN_DIR}/var/version_native"
 
 # clean up tmp folder
 rm -rf "${SDKMAN_DIR}"/tmp
@@ -193,7 +195,8 @@ echo ""
 echo ""
 echo "Successfully upgraded SDKMAN!"
 echo ""
-echo "Open a new terminal to start using SDKMAN $SDKMAN_VERSION."
+echo "Open a new terminal to start using SDKMAN $SDKMAN_VERSION"
+echo "with $SDKMAN_NATIVE_VERSION native extensions."
 echo ""
 echo "You are subscribed to the BETA channel."
 echo "To return to STABLE, simply follow the instructions on:"

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   guice,
   ws,
-  "com.github.sdkman" % "sdkman-mongodb-persistence" % "1.9",
+  "com.github.sdkman" % "sdkman-mongodb-persistence" % "2.3",
   "org.scalatest" %% "scalatest" % "3.0.0" % Test,
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test,
   "io.cucumber" %% "cucumber-scala" % "4.7.1" % Test,

--- a/features/installation.feature
+++ b/features/installation.feature
@@ -3,6 +3,7 @@ Feature: Installation
   Background:
     Given the stable CLI Version is "1.0.0"
     And the beta CLI Version is "latest+bff371f"
+    And the stable native CLI Version is "0.1.0"
 
   Scenario: Install SDKMAN stable from the command line
     When a request is made to the /install/stable endpoint
@@ -36,6 +37,7 @@ Feature: Installation
     And the response script starts with "#!/bin/bash"
     And the response script contains "# install:- channel: beta; version: latest+bff371f; api: https://beta.sdkman.io"
     And the response script contains "SDKMAN_VERSION="latest+bff371f""
+    And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
     And the response script contains "SDKMAN_SERVICE="https://beta.sdkman.io/2"
 
   Scenario: Install SDKMAN beta from the command line without updating rc files

--- a/features/selfupdate.feature
+++ b/features/selfupdate.feature
@@ -3,6 +3,7 @@ Feature: Selfupdate
   Background:
     Given the stable CLI Version is "1.0.0"
     And the beta CLI Version is "latest+bff371f"
+    And the stable native CLI Version is "0.1.0"
 
   Scenario: A selfupdate is performed on the Stable Channel
     When a request is made to the /selfupdate/stable endpoint
@@ -20,6 +21,7 @@ Feature: Selfupdate
     And the response script starts with "#!/bin/bash"
     And the response script contains "# selfupdate:- channel: beta; version: latest+bff371f; api: https://beta.sdkman.io"
     And the response script contains "SDKMAN_VERSION="latest+bff371f""
+    And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
     And the response script contains "SDKMAN_SERVICE="https://beta.sdkman.io/2""
 
   Scenario: A selfupdate is performed on the legacy Stable Channel

--- a/test/steps/Steps.scala
+++ b/test/steps/Steps.scala
@@ -17,11 +17,15 @@ class Steps extends ScalaDsl with EN with Matchers {
 
   And("""^the stable CLI Version is "(.*)"""") { stable: String =>
     stableCliVersion = stable
-    Mongo.insertCliVersions(stableCliVersion, betaCliVersion)
   }
 
   And("""^the beta CLI Version is "(.*)"""") { beta: String =>
     betaCliVersion = beta
+  }
+
+  And("""^the stable native CLI Version is "(.*)"""") { native: String =>
+    stableNativeCliVersion = native
+    Mongo.insertCliVersions(stableCliVersion, betaCliVersion, stableNativeCliVersion)
   }
 
   And("""^a request is made to the (.*) endpoint$""") { endpoint: String =>

--- a/test/steps/support/Mongo.scala
+++ b/test/steps/support/Mongo.scala
@@ -1,8 +1,7 @@
 package steps.support
 
+import io.sdkman.model.Application
 import java.util.concurrent.TimeUnit
-
-import io.sdkman.repos.Application
 import org.mongodb.scala.{MongoClient, _}
 import org.mongodb.scala.bson.collection.immutable.Document
 import org.bson.codecs.configuration.CodecRegistries.{fromProviders, fromRegistries}
@@ -26,12 +25,20 @@ object Mongo {
 
   lazy val appCollection: MongoCollection[Application] = db.getCollection("application")
 
-  def insertAliveOk(): Seq[Completed] = appCollection.insertOne(Application("OK", "", "")).results()
+  def insertAliveOk(): Seq[Completed] =
+    appCollection.insertOne(Application("OK", "", "", "")).results()
 
-  def insertAliveKo(): Seq[Completed] = appCollection.insertOne(Application("KO", "", "")).results()
+  def insertAliveKo(): Seq[Completed] =
+    appCollection.insertOne(Application("KO", "", "", "")).results()
 
-  def insertCliVersions(stableCliVersion: String, betaCliVersion: String): Seq[Completed] =
-    appCollection.insertOne(Application("OK", stableCliVersion, betaCliVersion)).results()
+  def insertCliVersions(
+      stableCliVersion: String,
+      betaCliVersion: String,
+      stableNativeCliVersion: String
+  ): Seq[Completed] =
+    appCollection
+      .insertOne(Application("OK", stableCliVersion, betaCliVersion, stableNativeCliVersion))
+      .results()
 
   def dropAppCollection(): Seq[Completed] = appCollection.drop().results()
 }

--- a/test/steps/support/World.scala
+++ b/test/steps/support/World.scala
@@ -13,4 +13,6 @@ object World {
   var stableCliVersion = ""
 
   var betaCliVersion = ""
+
+  var stableNativeCliVersion = ""
 }


### PR DESCRIPTION
- Propagate native version to CLI state on selfupdate.
- Propagate native version during beta install.
- Run scalafmt.
