### PR TITLE
Some improvements on the selfupdate beta hooks.

### DIFF
--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -116,51 +116,51 @@ sdkman_config_file="${SDKMAN_DIR}/etc/config"
 sdkman_config_file_tmp="${SDKMAN_DIR}/etc/config.tmp"
 touch "$sdkman_config_file"
 cp "$sdkman_config_file" "$sdkman_config_file_tmp"
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_answer') ]]; then
+if ! grep 'sdkman_auto_answer' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_auto_answer=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_insecure_ssl' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_insecure_ssl' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_insecure_ssl=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_curl_connect_timeout' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_curl_connect_timeout' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_curl_connect_timeout=7" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_curl_max_time' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_curl_max_time' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_curl_max_time=10" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_beta_channel' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_beta_channel' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_beta_channel=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_debug_mode' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_debug_mode' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_debug_mode=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_colour_enable' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_colour_enable' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_colour_enable=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_auto_env' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_auto_env' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_auto_env=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_rosetta2_compatible' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_rosetta2_compatible' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_rosetta2_compatible=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_checksum_enable' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_checksum_enable' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_checksum_enable=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_selfupdate_feature' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_selfupdate_feature' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_selfupdate_feature=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_auto_complete' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_auto_complete' "${sdkman_config_file_tmp}"; then
     if [ -z "$ZSH_VERSION" -a -z "$BASH_VERSION" ]; then
         echo "sdkman_auto_complete=false" >> "$sdkman_config_file_tmp"
     else
@@ -169,12 +169,12 @@ if [[ -z $(grep 'sdkman_auto_complete' "${sdkman_config_file_tmp}") ]]; then
 fi
 
 # migrate deprecated sdkman_selfupdate_enable configuration
-if [[ -z $(grep 'sdkman_selfupdate_enable' "${sdkman_config_file_tmp}") ]]; then
+if grep 'sdkman_selfupdate_enable' "${sdkman_config_file_tmp}"; then
     sed 's/sdkman_selfupdate_enable/sdkman_auto_update/' "$sdkman_config_file_tmp" > "${sdkman_config_file_tmp}.tmp"
     mv "${sdkman_config_file_tmp}.tmp" "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_auto_update' "${sdkman_config_file_tmp}") ]]; then
+if ! grep 'sdkman_auto_update' "${sdkman_config_file_tmp}"; then
 	echo "sdkman_auto_update=true" >> "$sdkman_config_file_tmp"
 fi
 

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -120,51 +120,51 @@ if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_answer') ]]; then
 	echo "sdkman_auto_answer=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_selfupdate_enable') ]]; then
+if [[ -z $(grep 'sdkman_selfupdate_enable' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_selfupdate_enable=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_insecure_ssl') ]]; then
+if [[ -z $(grep 'sdkman_insecure_ssl' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_insecure_ssl=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_curl_connect_timeout') ]]; then
+if [[ -z $(grep 'sdkman_curl_connect_timeout' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_curl_connect_timeout=7" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_curl_max_time') ]]; then
+if [[ -z $(grep 'sdkman_curl_max_time' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_curl_max_time=10" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_beta_channel') ]]; then
+if [[ -z $(grep 'sdkman_beta_channel' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_beta_channel=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_debug_mode') ]]; then
+if [[ -z $(grep 'sdkman_debug_mode' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_debug_mode=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_colour_enable') ]]; then
+if [[ -z $(grep 'sdkman_colour_enable' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_colour_enable=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_env') ]]; then
+if [[ -z $(grep 'sdkman_auto_env' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_auto_env=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_rosetta2_compatible') ]]; then
+if [[ -z $(grep 'sdkman_rosetta2_compatible' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_rosetta2_compatible=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_checksum_enable') ]]; then
+if [[ -z $(grep 'sdkman_checksum_enable' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_checksum_enable=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_selfupdate_feature') ]]; then
+if [[ -z $(grep 'sdkman_selfupdate_feature' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_selfupdate_feature=true" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_complete') ]]; then
+if [[ -z $(grep 'sdkman_auto_complete' "${sdkman_config_file_tmp}") ]]; then
     if [ -z "$ZSH_VERSION" -a -z "$BASH_VERSION" ]; then
         echo "sdkman_auto_complete=false" >> "$sdkman_config_file_tmp"
     else
@@ -173,12 +173,12 @@ if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_complete') ]]; th
 fi
 
 # migrate deprecated sdkman_selfupdate_enable configuration
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_selfupdate_enable') ]]; then
+if [[ -z $(grep 'sdkman_selfupdate_enable' "${sdkman_config_file_tmp}") ]]; then
     sed 's/sdkman_selfupdate_enable/sdkman_auto_update/' "$sdkman_config_file_tmp" > "${sdkman_config_file_tmp}.tmp"
     mv "${sdkman_config_file_tmp}.tmp" "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_update') ]]; then
+if [[ -z $(grep 'sdkman_auto_update' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_auto_update=true" >> "$sdkman_config_file_tmp"
 fi
 

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -173,8 +173,10 @@ if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_complete') ]]; th
 fi
 
 # migrate deprecated sdkman_selfupdate_enable configuration
-sed 's/sdkman_selfupdate_enable/sdkman_auto_update/' "$sdkman_config_file_tmp" > "${sdkman_config_file_tmp}.tmp" &&
+if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_selfupdate_enable') ]]; then
+    sed 's/sdkman_selfupdate_enable/sdkman_auto_update/' "$sdkman_config_file_tmp" > "${sdkman_config_file_tmp}.tmp"
     mv "${sdkman_config_file_tmp}.tmp" "$sdkman_config_file_tmp"
+fi
 
 if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_update') ]]; then
 	echo "sdkman_auto_update=true" >> "$sdkman_config_file_tmp"

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -120,10 +120,6 @@ if [[ -z $(cat "${sdkman_config_file_tmp}" | grep 'sdkman_auto_answer') ]]; then
 	echo "sdkman_auto_answer=false" >> "$sdkman_config_file_tmp"
 fi
 
-if [[ -z $(grep 'sdkman_selfupdate_enable' "${sdkman_config_file_tmp}") ]]; then
-	echo "sdkman_selfupdate_enable=true" >> "$sdkman_config_file_tmp"
-fi
-
 if [[ -z $(grep 'sdkman_insecure_ssl' "${sdkman_config_file_tmp}") ]]; then
 	echo "sdkman_insecure_ssl=false" >> "$sdkman_config_file_tmp"
 fi


### PR DESCRIPTION
Contains the following improvements:
* Only migrate `sdkman_selfupdate_enable` config if it is present
* Simplify grep expressions in selfupdate beta hook.
* Fix bug that keeps adding `sdkman_selfupdate_enable`