### PR TITLE
Add native support to beta

### DIFF
--- a/app/controllers/InstallController.scala
+++ b/app/controllers/InstallController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import domain.Platform
 import play.api.Configuration
 import play.api.mvc.{AbstractController, ControllerComponents}
 import repo.ApplicationRepo
@@ -17,7 +18,7 @@ class InstallController @Inject() (
 
   private val betaBaseUrlO = configUrl("service.betaBaseUrl")
 
-  def install(beta: Boolean, rcUpdate: Option[Boolean]) = Action.async { _ =>
+  def install(beta: Boolean, platformId: String, rcUpdate: Option[Boolean]) = Action.async { _ =>
     appRepo.findApplication().map { maybeApp =>
       val response = for {
         stableBaseUrl <- stableBaseUrlO
@@ -33,6 +34,7 @@ class InstallController @Inject() (
               cliVersion = betaVersion,
               cliNativeVersion = stableNativeVersion,
               baseUrl = betaBaseUrl,
+              platform = Platform(platformId).native,
               rcUpdate = rcUpdate.getOrElse(true),
               beta = beta
             )

--- a/app/controllers/SelfUpdateController.scala
+++ b/app/controllers/SelfUpdateController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import domain.Platform
 import play.api.Configuration
 import play.api.mvc._
 import repo.ApplicationRepo
@@ -17,7 +18,7 @@ class SelfUpdateController @Inject() (
 
   private val betaBaseUrlO = configUrl("service.betaBaseUrl")
 
-  def selfUpdate(beta: Boolean) = Action.async { _ =>
+  def selfUpdate(beta: Boolean, platformId: String) = Action.async { _ =>
     appRepo.findApplication().map { maybeApp =>
       val response = for {
         stableBaseUrl <- stableBaseUrlO
@@ -26,6 +27,7 @@ class SelfUpdateController @Inject() (
         stableVersion       = app.stableCliVersion
         betaVersion         = app.betaCliVersion
         stableNativeVersion = app.stableNativeCliVersion
+        platform = Platform(platformId).native
       } yield
         if (beta) {
           Ok(
@@ -33,6 +35,7 @@ class SelfUpdateController @Inject() (
               cliVersion = betaVersion,
               cliNativeVersion = stableNativeVersion,
               baseUrl = betaBaseUrl,
+              platform = platform,
               beta = beta
             )
           )

--- a/app/domain/domain.scala
+++ b/app/domain/domain.scala
@@ -11,7 +11,7 @@ object Candidate {
   val JMC    = Candidate("jmc")
 }
 
-case class Platform(distribution: String, name: String)
+case class Platform(distribution: String, name: String, triple: Option[String] = None)
 
 object Platform {
 
@@ -36,13 +36,13 @@ object Platform {
   private val CygwinPattern = "(cygwin|mingw64|msys).*".r
 
   val LinuxX32     = Platform("LINUX_32", "Linux 32bit")
-  val LinuxX64     = Platform("LINUX_64", "Linux 64bit")
+  val LinuxX64     = Platform("LINUX_64", "Linux 64bit", Some("x86_64-unknown-linux-gnu"))
   val LinuxARM32SF = Platform("LINUX_ARM32SF", "Linux ARM 32bit Soft Float")
   val LinuxARM32HF = Platform("LINUX_ARM32HF", "Linux ARM 32bit Hard Float")
-  val LinuxARM64   = Platform("LINUX_ARM64", "Linux ARM 64bit")
-  val MacX64       = Platform("MAC_OSX", "macOS 64bit")
-  val MacARM64     = Platform("MAC_ARM64", "macOS ARM 64bit")
-  val Windows64    = Platform("WINDOWS_64", "Cygwin")
+  val LinuxARM64   = Platform("LINUX_ARM64", "Linux ARM 64bit", Some("aarch64-unknown-linux-gnu"))
+  val MacX64       = Platform("MAC_OSX", "macOS 64bit", Some("x86_64-apple-darwin"))
+  val MacARM64     = Platform("MAC_ARM64", "macOS ARM 64bit", Some("aarch64-apple-darwin"))
+  val Windows64    = Platform("WINDOWS_64", "Cygwin", Some("x86_64-pc-windows-msvc"))
   val FreeBSD      = Platform("FREE_BSD", "FreeBSD")
   val SunOS        = Platform("SUN_OS", "Solaris")
 

--- a/app/domain/domain.scala
+++ b/app/domain/domain.scala
@@ -11,7 +11,9 @@ object Candidate {
   val JMC    = Candidate("jmc")
 }
 
-case class Platform(distribution: String, name: String, triple: Option[String] = None)
+case class Platform(distribution: String, name: String, triple: Option[String] = None) {
+  val native: Option[Platform] = Some(this).filter(_.triple.isDefined)
+}
 
 object Platform {
 

--- a/app/views/includes/install_archive.scala.txt
+++ b/app/views/includes/install_archive.scala.txt
@@ -1,0 +1,46 @@
+@(url: String, targetZip: String, baseFolder: String)
+# fetch distribution
+download_url="@url"
+sdkman_zip_file="@targetZip"
+sdkman_zip_base_folder="@baseFolder"
+__sdkman_echo_debug "Download new scripts from: ${download_url}"
+__sdkman_echo_debug "Download new scripts to: ${sdkman_zip_file}"
+echo "* Downloading..."
+curl --fail --location --progress-bar "$download_url" > "$sdkman_zip_file"
+
+# check integrity
+echo "* Checking archive integrity..."
+ARCHIVE_OK=$(unzip -qt "$sdkman_zip_file" | grep 'No errors detected in compressed data')
+if [[ -z "$ARCHIVE_OK" ]]; then
+	echo "Downloaded zip archive corrupt. Are you connected to the internet?"
+	echo ""
+	echo "If problems persist, please ask for help on our Slack:"
+	echo "* easy sign up: https://slack.sdkman.io/"
+	echo "* report on channel: https://sdkman.slack.com/app_redirect?channel=user-issues"
+	exit
+fi
+
+# extract
+echo "* Extracting archive..."
+__sdkman_echo_debug "Extract script archive ${sdkman_zip_file}..."
+__sdkman_echo_debug "Unzipping script archive to: ${sdkman_tmp_folder}"
+if [[ "$cygwin" == 'true' ]]; then
+	__sdkman_echo_debug "Cygwin detected - normalizing paths for unzip..."
+	sdkman_tmp_folder=$(cygpath -w "$sdkman_tmp_folder")
+	sdkman_zip_file=$(cygpath -w "$sdkman_zip_file")
+	sdkman_zip_base_folder=$(cygpath -w "$sdkman_zip_base_folder")
+fi
+unzip -qo "$sdkman_zip_file" -d "$sdkman_tmp_folder"
+
+# copy in place
+
+echo "* Copying archive contents..."
+__sdkman_echo_debug "Copying over archive contents to: ${SDKMAN_DIR}"
+cp -rf "${sdkman_zip_base_folder}/"* "$SDKMAN_DIR"
+
+# clean up
+echo "* Cleaning up..."
+rm -rf "$sdkman_zip_base_folder"
+rm -rf "$sdkman_zip_file"
+
+echo ""

--- a/app/views/includes/install_archive.scala.txt
+++ b/app/views/includes/install_archive.scala.txt
@@ -3,8 +3,6 @@
 download_url="@url"
 sdkman_zip_file="@targetZip"
 sdkman_zip_base_folder="@baseFolder"
-__sdkman_echo_debug "Download new scripts from: ${download_url}"
-__sdkman_echo_debug "Download new scripts to: ${sdkman_zip_file}"
 echo "* Downloading..."
 curl --fail --location --progress-bar "$download_url" > "$sdkman_zip_file"
 
@@ -22,10 +20,7 @@ fi
 
 # extract
 echo "* Extracting archive..."
-__sdkman_echo_debug "Extract script archive ${sdkman_zip_file}..."
-__sdkman_echo_debug "Unzipping script archive to: ${sdkman_tmp_folder}"
 if [[ "$cygwin" == 'true' ]]; then
-	__sdkman_echo_debug "Cygwin detected - normalizing paths for unzip..."
 	sdkman_tmp_folder=$(cygpath -w "$sdkman_tmp_folder")
 	sdkman_zip_file=$(cygpath -w "$sdkman_zip_file")
 	sdkman_zip_base_folder=$(cygpath -w "$sdkman_zip_base_folder")
@@ -35,7 +30,6 @@ unzip -qo "$sdkman_zip_file" -d "$sdkman_tmp_folder"
 # copy in place
 
 echo "* Copying archive contents..."
-__sdkman_echo_debug "Copying over archive contents to: ${SDKMAN_DIR}"
 cp -rf "${sdkman_zip_base_folder}/"* "$SDKMAN_DIR"
 
 # clean up

--- a/app/views/includes/statusline.scala.txt
+++ b/app/views/includes/statusline.scala.txt
@@ -1,3 +1,3 @@
 @(hook: String, cliVersion: String, cliNativeVersion: String, baseUrl: String, beta: Boolean)
 
-# @hook:- channel: @if(beta) {beta} else {stable}; cliVersion: @cliVersion; cliNativeVersion: @cliNativeVersion, api: @baseUrl
+# @hook:- channel: @if(beta) {beta} else {stable}; cliVersion: @cliVersion; cliNativeVersion: @cliNativeVersion; api: @baseUrl

--- a/app/views/includes/statusline.scala.txt
+++ b/app/views/includes/statusline.scala.txt
@@ -1,7 +1,3 @@
-@(hook: String, cliVersion: String, baseUrl: String, beta: Boolean)
+@(hook: String, cliVersion: String, cliNativeVersion: String, baseUrl: String, beta: Boolean)
 
-@if(beta){
-# @hook:- channel: beta; version: @cliVersion; api: @baseUrl
-} else {
-# @hook:- channel: stable; version: @cliVersion; api: @baseUrl
-}
+# @hook:- channel: @if(beta) {beta} else {stable}; cliVersion: @cliVersion; cliNativeVersion: @cliNativeVersion, api: @baseUrl

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -4,7 +4,7 @@
 
 @includes.trap_errors()
 
-@includes.statusline("install", cliVersion, baseUrl, beta)
+@includes.statusline("install", cliVersion, cliNativeVersion, baseUrl, beta)
 
 # Global variables
 SDKMAN_SERVICE="@baseUrl"

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -20,8 +20,6 @@ fi
 
 # Local variables
 sdkman_tmp_folder="${SDKMAN_DIR}/tmp"
-sdkman_zip_file="${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}.zip"
-sdkman_zip_base_folder="${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
 sdkman_ext_folder="${SDKMAN_DIR}/ext"
 sdkman_etc_folder="${SDKMAN_DIR}/etc"
 sdkman_var_folder="${SDKMAN_DIR}/var"
@@ -81,32 +79,13 @@ echo "sdkman_insecure_ssl=false" >> "$sdkman_config_file"
 echo "sdkman_rosetta2_compatible=false" >> "$sdkman_config_file"
 echo "sdkman_selfupdate_feature=true" >> "$sdkman_config_file"
 
-echo "Download script archive..."
-curl --location --progress-bar "${SDKMAN_SERVICE}/broker/download/sdkman/install/${SDKMAN_VERSION}/${SDKMAN_PLATFORM}" > "$sdkman_zip_file"
-
-ARCHIVE_OK=$(unzip -qt "$sdkman_zip_file" | grep 'No errors detected in compressed data')
-if [[ -z "$ARCHIVE_OK" ]]; then
-	echo "Downloaded zip archive corrupt. Are you connected to the internet?"
-	echo ""
-	echo "If problems persist, please ask for help on our Slack:"
-	echo "* easy sign up: https://slack.sdkman.io/"
-	echo "* report on channel: https://sdkman.slack.com/app_redirect?channel=user-issues"
-	rm -rf "$SDKMAN_DIR"
-	exit 1
-fi
-
-echo "Extract script archive..."
-if [[ "$cygwin" == 'true' ]]; then
-	echo "Cygwin detected - normalizing paths for unzip..."
-	sdkman_tmp_folder=$(cygpath -w "$sdkman_tmp_folder")
-	sdkman_zip_file=$(cygpath -w "$sdkman_zip_file")
-	sdkman_zip_base_folder=$(cygpath -w "$sdkman_zip_base_folder")
-fi
-unzip -qo "$sdkman_zip_file" -d "$sdkman_tmp_folder"
-
-echo "Install scripts..."
-mv "${sdkman_zip_base_folder}/"* "$SDKMAN_DIR"
-rm -rf "$sdkman_zip_base_folder"
+# script cli distribution
+echo "Installing script cli archive..."
+@includes.install_archive(
+    "${SDKMAN_SERVICE}/broker/download/sdkman/install/${SDKMAN_VERSION}/${SDKMAN_PLATFORM}",
+    "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}.zip",
+    "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
+)
 
 echo "Set version to $SDKMAN_VERSION ..."
 echo "$SDKMAN_VERSION" > "${SDKMAN_DIR}/var/version"

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -88,9 +88,9 @@ echo "Installing script cli archive..."
     "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
 )
 
+@for(p <- platform) {
 # native cli distribution for supported platforms only
 echo "Installing native cli archive..."
-@for(p <- platform) {
 native_triple="@p.triple"
 @includes.install_archive(
     "${SDKMAN_SERVICE}/broker/download/native/selfupdate/${SDKMAN_NATIVE_VERSION}/${SDKMAN_PLATFORM}",

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -1,4 +1,5 @@
-@(cliVersion: String, cliNativeVersion: String, baseUrl: String, rcUpdate: Boolean, beta: Boolean)#!/bin/bash
+@import domain.Platform
+@(cliVersion: String, cliNativeVersion: String, baseUrl: String, platform: Option[Platform], rcUpdate: Boolean, beta: Boolean)#!/bin/bash
 @includes.license()
 
 @includes.trap_errors()
@@ -86,6 +87,17 @@ echo "Installing script cli archive..."
     "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}.zip",
     "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
 )
+
+# native cli distribution for supported platforms only
+echo "Installing native cli archive..."
+@for(p <- platform) {
+native_triple="@p.triple"
+@includes.install_archive(
+    "${SDKMAN_SERVICE}/broker/download/native/selfupdate/${SDKMAN_NATIVE_VERSION}/${SDKMAN_PLATFORM}",
+    "${sdkman_tmp_folder}/sdkman-native-${SDKMAN_NATIVE_VERSION}.zip",
+    "${sdkman_tmp_folder}/sdkman-cli-native-${SDKMAN_NATIVE_VERSION}-${native_triple}"
+)
+}
 
 echo "Set version to $SDKMAN_VERSION ..."
 echo "$SDKMAN_VERSION" > "${SDKMAN_DIR}/var/version"

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -2,9 +2,9 @@
 @(cliVersion: String, cliNativeVersion: String, baseUrl: String, platform: Option[Platform], rcUpdate: Boolean, beta: Boolean)#!/bin/bash
 @includes.license()
 
-@includes.trap_errors()
-
 @includes.statusline("install", cliVersion, cliNativeVersion, baseUrl, beta)
+
+@includes.trap_errors()
 
 # Global variables
 SDKMAN_SERVICE="@baseUrl"

--- a/app/views/install_stable.scala.txt
+++ b/app/views/install_stable.scala.txt
@@ -1,7 +1,7 @@
 @(cliVersion: String, baseUrl: String, rcUpdate: Boolean, beta: Boolean)#!/bin/bash
 @includes.license()
 
-@includes.statusline("install", cliVersion, baseUrl, beta)
+@includes.statusline("install", cliVersion, "NA", baseUrl, beta)
 
 # Global variables
 SDKMAN_SERVICE="@baseUrl"

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -48,9 +48,9 @@ echo "Installing script cli archive..."
     "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
 )
 
+@for(p <- platform) {
 # native cli distribution for supported platforms only
 echo "Installing native cli archive..."
-@for(p <- platform) {
 native_triple="@p.triple"
 @includes.install_archive(
     "${SDKMAN_SERVICE}/broker/download/native/selfupdate/${SDKMAN_NATIVE_VERSION}/${SDKMAN_PLATFORM}",

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -4,9 +4,9 @@
 @(cliVersion: String, cliNativeVersion: String, baseUrl: String, platform: Option[Platform], beta: Boolean)#!/bin/bash
 @includes.license()
 
-@includes.trap_errors()
-
 @includes.statusline("selfupdate", cliVersion, cliNativeVersion, baseUrl, beta)
+
+@includes.trap_errors()
 
 # Global variables
 SDKMAN_SERVICE="@baseUrl"

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -40,80 +40,24 @@ sdkman_src_folder="${SDKMAN_DIR}/src"
 sdkman_archives_folder="${SDKMAN_DIR}/archives"
 sdkman_tmp_folder="${SDKMAN_DIR}/tmp"
 
-# fetch new cli distribution and check integrity
-download_url="${SDKMAN_SERVICE}/broker/download/sdkman/selfupdate/${SDKMAN_VERSION}/${SDKMAN_PLATFORM}"
-sdkman_zip_file="${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}.zip"
-sdkman_zip_base_folder="${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
-__sdkman_echo_debug "Download new scripts from: ${download_url}"
-__sdkman_echo_debug "Download new scripts to: ${sdkman_zip_file}"
-curl --fail --location --progress-bar "$download_url" > "$sdkman_zip_file"
+# script cli distribution
+echo "Installing script cli archive..."
+@includes.install_archive(
+    "${SDKMAN_SERVICE}/broker/download/sdkman/selfupdate/${SDKMAN_VERSION}/${SDKMAN_PLATFORM}",
+    "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}.zip",
+    "${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
+)
 
-ARCHIVE_OK=$(unzip -qt "$sdkman_zip_file" | grep 'No errors detected in compressed data')
-if [[ -z "$ARCHIVE_OK" ]]; then
-	echo "Downloaded zip archive corrupt. Are you connected to the internet?"
-	echo ""
-	echo "If problems persist, please ask for help on our Slack:"
-	echo "* easy sign up: https://slack.sdkman.io/"
-	echo "* report on channel: https://sdkman.slack.com/app_redirect?channel=user-issues"
-	exit
-fi
-
-# extract new distribution
-__sdkman_echo_debug "Extract script archive..."
-__sdkman_echo_debug "Unzipping script archive to: ${sdkman_tmp_folder}"
-if [[ "$cygwin" == 'true' ]]; then
-	__sdkman_echo_debug "Cygwin detected - normalizing paths for unzip..."
-	sdkman_tmp_folder=$(cygpath -w "$sdkman_tmp_folder")
-	sdkman_zip_file=$(cygpath -w "$sdkman_zip_file")
-	sdkman_zip_base_folder=$(cygpath -w "$sdkman_zip_base_folder")
-fi
-unzip -qo "$sdkman_zip_file" -d "$sdkman_tmp_folder"
-
-echo "Install scripts..."
-rm -rf $sdkman_bin_folder
-rm -rf $sdkman_contrib_folder
-rm -rf $sdkman_src_folder
-mv "${sdkman_zip_base_folder}/"* "$SDKMAN_DIR"
-rm -rf "$sdkman_zip_base_folder"
-rm -rf "$sdkman_archives_folder"
-
-
+# native cli distribution for supported platforms only
+echo "Installing native cli archive..."
 @for(p <- platform) {
-# fetch new native distribution and check integrity
-download_url="${SDKMAN_SERVICE}/broker/download/native/selfupdate/${SDKMAN_NATIVE_VERSION}/${SDKMAN_PLATFORM}"
-sdkman_zip_file="${sdkman_tmp_folder}/sdkman-native-${SDKMAN_NATIVE_VERSION}.zip"
-sdkman_zip_base_folder="${sdkman_tmp_folder}/sdkman-cli-native-${SDKMAN_NATIVE_VERSION}-@{p.triple}"
-__sdkman_echo_debug "Download new native binaries from: ${download_url}"
-__sdkman_echo_debug "Download new native binaries to: ${sdkman_zip_file}"
-curl --fail --location --progress-bar "$download_url" > "$sdkman_zip_file"
-
-ARCHIVE_OK=$(unzip -qt "$sdkman_zip_file" | grep 'No errors detected in compressed data')
-if [[ -z "$ARCHIVE_OK" ]]; then
-	echo "Downloaded zip archive corrupt. Are you connected to the internet?"
-	echo ""
-	echo "If problems persist, please ask for help on our Slack:"
-	echo "* easy sign up: https://slack.sdkman.io/"
-	echo "* report on channel: https://sdkman.slack.com/app_redirect?channel=user-issues"
-	exit
-fi
-
-echo "Install binaries..."
-rm -rf $sdkman_libexec_folder
-mv "${sdkman_zip_base_folder}/"* "$SDKMAN_DIR"
-rm -rf "$sdkman_zip_base_folder"
-
-# extract new distribution
-__sdkman_echo_debug "Extract script archive..."
-__sdkman_echo_debug "Unzipping script archive to: ${sdkman_tmp_folder}"
-if [[ "$cygwin" == 'true' ]]; then
-	__sdkman_echo_debug "Cygwin detected - normalizing paths for unzip..."
-	sdkman_tmp_folder=$(cygpath -w "$sdkman_tmp_folder")
-	sdkman_zip_file=$(cygpath -w "$sdkman_zip_file")
-	sdkman_zip_base_folder=$(cygpath -w "$sdkman_zip_base_folder")
-fi
-unzip -qo "$sdkman_zip_file" -d "$sdkman_tmp_folder"
+native_triple="@p.triple"
+@includes.install_archive(
+    "${SDKMAN_SERVICE}/broker/download/native/selfupdate/${SDKMAN_NATIVE_VERSION}/${SDKMAN_PLATFORM}",
+    "${sdkman_tmp_folder}/sdkman-native-${SDKMAN_NATIVE_VERSION}.zip",
+    "${sdkman_tmp_folder}/sdkman-cli-native-${SDKMAN_NATIVE_VERSION}-${native_triple}"
+)
 }
-
 
 # prepare candidates
 SDKMAN_CANDIDATES_CSV=$(curl -s "$SDKMAN_SERVICE/candidates/all")
@@ -122,7 +66,7 @@ echo "$SDKMAN_CANDIDATES_CSV" > "${SDKMAN_DIR}/var/candidates"
 __sdkman_echo_debug "Overwritten cache: $(cat "${SDKMAN_DIR}/var/candidates")"
 
 # prime config file
-echo "Update config file..."
+echo "Updating config file..."
 echo ""
 sdkman_config_file="${SDKMAN_DIR}/etc/config"
 sdkman_config_file_tmp="${SDKMAN_DIR}/etc/config.tmp"
@@ -192,7 +136,7 @@ fi
 
 # create config backup and overwrite with updated config
 echo ""
-echo "Create config file backup..."
+echo "Creating config file backup..."
 @defining(LocalDateTime.now()) { now =>
     @defining(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")) { formatter =>
 sdkman_config_file_backup="${sdkman_config_file}-@cliVersion-@{now.format(formatter)}.bak"

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -6,7 +6,7 @@
 
 @includes.trap_errors()
 
-@includes.statusline("selfupdate", cliVersion, baseUrl, beta)
+@includes.statusline("selfupdate", cliVersion, cliNativeVersion, baseUrl, beta)
 
 # Global variables
 SDKMAN_SERVICE="@baseUrl"

--- a/app/views/selfupdate_beta.scala.txt
+++ b/app/views/selfupdate_beta.scala.txt
@@ -1,6 +1,7 @@
+@import domain.Platform
 @import java.time.LocalDateTime
 @import java.time.format.DateTimeFormatter
-@(cliVersion: String, cliNativeVersion: String, baseUrl: String, beta: Boolean)#!/bin/bash
+@(cliVersion: String, cliNativeVersion: String, baseUrl: String, platform: Option[Platform], beta: Boolean)#!/bin/bash
 @includes.license()
 
 @includes.trap_errors()
@@ -11,7 +12,9 @@
 SDKMAN_SERVICE="@baseUrl"
 SDKMAN_VERSION="@cliVersion"
 SDKMAN_NATIVE_VERSION="@cliNativeVersion"
-SDKMAN_PLATFORM=$(uname)
+if [[ -z "$SDKMAN_PLATFORM" ]]; then
+    SDKMAN_PLATFORM="unknown"
+fi
 
 @includes.os()
 
@@ -31,18 +34,19 @@ if [ -z "$SDKMAN_DIR" ]; then
 fi
 
 sdkman_bin_folder="${SDKMAN_DIR}/bin"
+sdkman_libexec_folder="${SDKMAN_DIR}/libexec"
 sdkman_contrib_folder="${SDKMAN_DIR}/contrib"
 sdkman_src_folder="${SDKMAN_DIR}/src"
 sdkman_archives_folder="${SDKMAN_DIR}/archives"
 sdkman_tmp_folder="${SDKMAN_DIR}/tmp"
+
+# fetch new cli distribution and check integrity
+download_url="${SDKMAN_SERVICE}/broker/download/sdkman/selfupdate/${SDKMAN_VERSION}/${SDKMAN_PLATFORM}"
 sdkman_zip_file="${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}.zip"
 sdkman_zip_base_folder="${sdkman_tmp_folder}/sdkman-${SDKMAN_VERSION}"
-
-# fetch new distribution and check integrity
-download_url="${SDKMAN_SERVICE}/broker/download/sdkman/selfupdate/${SDKMAN_VERSION}/${SDKMAN_PLATFORM}"
 __sdkman_echo_debug "Download new scripts from: ${download_url}"
 __sdkman_echo_debug "Download new scripts to: ${sdkman_zip_file}"
-curl --location --progress-bar "$download_url" > "$sdkman_zip_file"
+curl --fail --location --progress-bar "$download_url" > "$sdkman_zip_file"
 
 ARCHIVE_OK=$(unzip -qt "$sdkman_zip_file" | grep 'No errors detected in compressed data')
 if [[ -z "$ARCHIVE_OK" ]]; then
@@ -72,6 +76,44 @@ rm -rf $sdkman_src_folder
 mv "${sdkman_zip_base_folder}/"* "$SDKMAN_DIR"
 rm -rf "$sdkman_zip_base_folder"
 rm -rf "$sdkman_archives_folder"
+
+
+@for(p <- platform) {
+# fetch new native distribution and check integrity
+download_url="${SDKMAN_SERVICE}/broker/download/native/selfupdate/${SDKMAN_NATIVE_VERSION}/${SDKMAN_PLATFORM}"
+sdkman_zip_file="${sdkman_tmp_folder}/sdkman-native-${SDKMAN_NATIVE_VERSION}.zip"
+sdkman_zip_base_folder="${sdkman_tmp_folder}/sdkman-cli-native-${SDKMAN_NATIVE_VERSION}-@{p.triple}"
+__sdkman_echo_debug "Download new native binaries from: ${download_url}"
+__sdkman_echo_debug "Download new native binaries to: ${sdkman_zip_file}"
+curl --fail --location --progress-bar "$download_url" > "$sdkman_zip_file"
+
+ARCHIVE_OK=$(unzip -qt "$sdkman_zip_file" | grep 'No errors detected in compressed data')
+if [[ -z "$ARCHIVE_OK" ]]; then
+	echo "Downloaded zip archive corrupt. Are you connected to the internet?"
+	echo ""
+	echo "If problems persist, please ask for help on our Slack:"
+	echo "* easy sign up: https://slack.sdkman.io/"
+	echo "* report on channel: https://sdkman.slack.com/app_redirect?channel=user-issues"
+	exit
+fi
+
+echo "Install binaries..."
+rm -rf $sdkman_libexec_folder
+mv "${sdkman_zip_base_folder}/"* "$SDKMAN_DIR"
+rm -rf "$sdkman_zip_base_folder"
+
+# extract new distribution
+__sdkman_echo_debug "Extract script archive..."
+__sdkman_echo_debug "Unzipping script archive to: ${sdkman_tmp_folder}"
+if [[ "$cygwin" == 'true' ]]; then
+	__sdkman_echo_debug "Cygwin detected - normalizing paths for unzip..."
+	sdkman_tmp_folder=$(cygpath -w "$sdkman_tmp_folder")
+	sdkman_zip_file=$(cygpath -w "$sdkman_zip_file")
+	sdkman_zip_base_folder=$(cygpath -w "$sdkman_zip_base_folder")
+fi
+unzip -qo "$sdkman_zip_file" -d "$sdkman_tmp_folder"
+}
+
 
 # prepare candidates
 SDKMAN_CANDIDATES_CSV=$(curl -s "$SDKMAN_SERVICE/candidates/all")

--- a/app/views/selfupdate_stable.scala.txt
+++ b/app/views/selfupdate_stable.scala.txt
@@ -3,7 +3,7 @@
 @(cliVersion: String, baseUrl: String, beta: Boolean)#!/bin/bash
 @includes.license()
 
-@includes.statusline("selfupdate", cliVersion, baseUrl, beta)
+@includes.statusline("selfupdate", cliVersion, "NA", baseUrl, beta)
 
 # Global variables
 SDKMAN_SERVICE="@baseUrl"

--- a/conf/routes
+++ b/conf/routes
@@ -5,6 +5,7 @@
 GET        /alive                                             controllers.HealthController.alive
 GET        /install/beta                                      controllers.InstallController.install(beta: Boolean = true, rcupdate: Option[Boolean])
 GET        /install/stable                                    controllers.InstallController.install(beta: Boolean = false, rcupdate: Option[Boolean])
-GET        /selfupdate/beta                                   controllers.SelfUpdateController.selfUpdate(beta: Boolean = true)
-GET        /selfupdate/stable                                 controllers.SelfUpdateController.selfUpdate(beta: Boolean ?= false)
+GET        /selfupdate/beta/:platform                         controllers.SelfUpdateController.selfUpdate(beta: Boolean = true, platform)
+GET        /selfupdate/beta                                   controllers.SelfUpdateController.selfUpdate(beta: Boolean = true, platform = "unknown")
+GET        /selfupdate/stable                                 controllers.SelfUpdateController.selfUpdate(beta: Boolean ?= false, platform = "unknown")
 GET        /hooks/:phase/:candidate/:version/:platform        controllers.HooksController.hook(phase, candidate, version, platform)

--- a/conf/routes
+++ b/conf/routes
@@ -3,8 +3,9 @@
 # ~~~~
 
 GET        /alive                                             controllers.HealthController.alive
-GET        /install/beta                                      controllers.InstallController.install(beta: Boolean = true, rcupdate: Option[Boolean])
-GET        /install/stable                                    controllers.InstallController.install(beta: Boolean = false, rcupdate: Option[Boolean])
+GET        /install/beta/:platform                            controllers.InstallController.install(beta: Boolean = true, platform, rcupdate: Option[Boolean])
+GET        /install/beta                                      controllers.InstallController.install(beta: Boolean = true, platform = "unknown", rcupdate: Option[Boolean])
+GET        /install/stable                                    controllers.InstallController.install(beta: Boolean = false, platform = "unknown", rcupdate: Option[Boolean])
 GET        /selfupdate/beta/:platform                         controllers.SelfUpdateController.selfUpdate(beta: Boolean = true, platform)
 GET        /selfupdate/beta                                   controllers.SelfUpdateController.selfUpdate(beta: Boolean = true, platform = "unknown")
 GET        /selfupdate/stable                                 controllers.SelfUpdateController.selfUpdate(beta: Boolean ?= false, platform = "unknown")

--- a/features/installation.feature
+++ b/features/installation.feature
@@ -10,7 +10,7 @@ Feature: Installation
     Then a 200 status code is received
     And a "text/plain; charset=UTF-8" content type is received
     And the response script starts with "#!/bin/bash"
-    And the response script contains "# install:- channel: stable; version: 1.0.0; api: https://api.sdkman.io"
+    And the response script contains "# install:- channel: stable; cliVersion: 1.0.0; cliNativeVersion: NA; api: https://api.sdkman.io/2"
     And the response script contains "SDKMAN_VERSION="1.0.0""
     And the response script contains "SDKMAN_SERVICE="https://api.sdkman.io/2"
 
@@ -35,7 +35,7 @@ Feature: Installation
     Then a 200 status code is received
     And a "text/plain; charset=UTF-8" content type is received
     And the response script starts with "#!/bin/bash"
-    And the response script contains "# install:- channel: beta; version: latest+bff371f; api: https://beta.sdkman.io"
+    And the response script contains "# install:- channel: beta; cliVersion: latest+bff371f; cliNativeVersion: 0.1.0; api: https://beta.sdkman.io/2"
     And the response script contains "SDKMAN_VERSION="latest+bff371f""
     And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
     And the response script contains "SDKMAN_SERVICE="https://beta.sdkman.io/2"

--- a/features/native.feature
+++ b/features/native.feature
@@ -1,0 +1,54 @@
+Feature: Native installation and selfupdate
+
+  Background:
+    Given the stable CLI Version is "1.0.0"
+    And the beta CLI Version is "latest+bff371f"
+    And the stable native CLI Version is "0.1.0"
+
+  Scenario: A selfupdate is performed on the beta channel for a know platform
+    When a request is made to the /selfupdate/beta/linuxx64 endpoint
+    Then a 200 status code is received
+    And the response script contains "# selfupdate:- channel: beta; cliVersion: latest+bff371f; cliNativeVersion: 0.1.0; api: https://beta.sdkman.io/2"
+    And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
+    And the response script contains "# native cli distribution for supported platforms only"
+    And the response script contains "native_triple="x86_64-unknown-linux-gnu""
+
+  Scenario: A selfupdate is performed on the beta channel for an unknown platform
+    When a request is made to the /selfupdate/beta/unknown endpoint
+    Then a 200 status code is received
+    And the response script contains "# selfupdate:- channel: beta; cliVersion: latest+bff371f; cliNativeVersion: 0.1.0; api: https://beta.sdkman.io/2"
+    And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
+    And the response script does not contain "# native cli distribution for supported platforms only"
+    And the response script does not contain "native_triple"
+
+  Scenario: An installation is performed on the beta channel for a know platform
+    When a request is made to the /install/beta/linuxx64 endpoint
+    Then a 200 status code is received
+    And the response script contains "# install:- channel: beta; cliVersion: latest+bff371f; cliNativeVersion: 0.1.0; api: https://beta.sdkman.io/2"
+    And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
+    And the response script contains "# native cli distribution for supported platforms only"
+    And the response script contains "native_triple="x86_64-unknown-linux-gnu""
+
+  Scenario: An installation is performed on the beta channel for an unknown platform
+    When a request is made to the /install/beta/unknown endpoint
+    Then a 200 status code is received
+    And the response script contains "# install:- channel: beta; cliVersion: latest+bff371f; cliNativeVersion: 0.1.0; api: https://beta.sdkman.io/2"
+    And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
+    And the response script does not contain "# native cli distribution for supported platforms only"
+    And the response script does not contain "native_triple"
+
+  Scenario: A selfupdate is performed on the stable channel for a know platform
+    When a request is made to the /selfupdate/stable/linuxx64 endpoint
+    Then a 404 status code is received
+
+  Scenario: A selfupdate is performed on the stable channel for an unknown platform
+    When a request is made to the /selfupdate/stable/unknown endpoint
+    Then a 404 status code is received
+
+  Scenario: An installation is performed on the stable channel for a know platform
+    When a request is made to the /install/stable/linuxx64 endpoint
+    Then a 404 status code is received
+
+  Scenario: An installation is performed on the stable channel for an unknown platform
+    When a request is made to the /install/stable/unknown endpoint
+    Then a 404 status code is received

--- a/features/selfupdate.feature
+++ b/features/selfupdate.feature
@@ -10,7 +10,7 @@ Feature: Selfupdate
     Then a 200 status code is received
     And a "text/plain; charset=UTF-8" content type is received
     And the response script starts with "#!/bin/bash"
-    And the response script contains "# selfupdate:- channel: stable; version: 1.0.0; api: https://api.sdkman.io/2"
+    And the response script contains "# selfupdate:- channel: stable; cliVersion: 1.0.0; cliNativeVersion: NA; api: https://api.sdkman.io/2"
     And the response script contains "SDKMAN_VERSION="1.0.0""
     And the response script contains "SDKMAN_SERVICE="https://api.sdkman.io/2""
 
@@ -19,7 +19,7 @@ Feature: Selfupdate
     Then a 200 status code is received
     And a "text/plain; charset=UTF-8" content type is received
     And the response script starts with "#!/bin/bash"
-    And the response script contains "# selfupdate:- channel: beta; version: latest+bff371f; api: https://beta.sdkman.io/2"
+    And the response script contains "# selfupdate:- channel: beta; cliVersion: latest+bff371f; cliNativeVersion: 0.1.0; api: https://beta.sdkman.io/2"
     And the response script contains "SDKMAN_VERSION="latest+bff371f""
     And the response script contains "SDKMAN_NATIVE_VERSION="0.1.0""
     And the response script contains "SDKMAN_SERVICE="https://beta.sdkman.io/2""
@@ -29,7 +29,7 @@ Feature: Selfupdate
     Then a 200 status code is received
     And a "text/plain; charset=UTF-8" content type is received
     And the response script starts with "#!/bin/bash"
-    And the response script contains "# selfupdate:- channel: stable; version: 1.0.0; api: https://api.sdkman.io/2"
+    And the response script contains "# selfupdate:- channel: stable; cliVersion: 1.0.0; cliNativeVersion: NA; api: https://api.sdkman.io/2"
     And the response script contains "SDKMAN_VERSION="1.0.0""
     And the response script contains "SDKMAN_SERVICE="https://api.sdkman.io/2""
 
@@ -38,6 +38,6 @@ Feature: Selfupdate
     Then a 200 status code is received
     And a "text/plain; charset=UTF-8" content type is received
     And the response script starts with "#!/bin/bash"
-    And the response script contains "# selfupdate:- channel: beta; version: latest+bff371f; api: https://beta.sdkman.io/2"
+    And the response script contains "# selfupdate:- channel: beta; cliVersion: latest+bff371f; cliNativeVersion: 0.1.0; api: https://beta.sdkman.io/2"
     And the response script contains "SDKMAN_VERSION="latest+bff371f""
     And the response script contains "SDKMAN_SERVICE="https://beta.sdkman.io/2""

--- a/test/utils/PlatformSpec.scala
+++ b/test/utils/PlatformSpec.scala
@@ -1,9 +1,9 @@
 package utils
 
 import domain.Platform
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{Matchers, OptionValues, WordSpec}
 
-class PlatformSpec extends WordSpec with Matchers {
+class PlatformSpec extends WordSpec with Matchers with OptionValues {
   "platform" should {
     "return some platform when presented with a valid client platform identifier" in {
       Platform("cygwin_nt-6.1") shouldBe Platform.Windows64
@@ -39,6 +39,14 @@ class PlatformSpec extends WordSpec with Matchers {
 
     "return none when presented with an unknown client platform identifier" in {
       Platform("exotic") shouldBe Platform.Exotic
+    }
+
+    "return a valid platform triple for platforms with native support" in {
+      Platform("linuxx64").triple.value shouldBe "x86_64-unknown-linux-gnu"
+      Platform("linuxarm64").triple.value shouldBe "aarch64-unknown-linux-gnu"
+      Platform("darwinx64").triple.value shouldBe "x86_64-apple-darwin"
+      Platform("darwinarm64").triple.value shouldBe "aarch64-apple-darwin"
+      Platform("cygwin_nt-6.1").triple.value shouldBe "x86_64-pc-windows-msvc"
     }
   }
 }


### PR DESCRIPTION
- Add support for platform triples on supported native platforms.
- Add native field based on triple to Platform instances.
- Rework beta selfupdate to support native binary download.
- Extract archive installation to common template.
- Apply common install_archive template to install beta script.
