### PR TITLE
Add relocation hooks

### DIFF
--- a/app/controllers/HooksController.scala
+++ b/app/controllers/HooksController.scala
@@ -80,6 +80,16 @@ class HooksController @Inject() (cc: ControllerComponents)
           case (Pre, _, _, _, _) =>
             Ok(views.txt.default_pre(candidate, version, platform))
 
+          //RELOCATE
+          case (Relocate, Java, _, MacX64 | MacARM64, _) =>
+            Ok(views.txt.java_relocate_osx_tarball(candidate, version, platform))
+          case (Relocate, JMC, _, MacX64 | MacARM64, _) =>
+            Ok(views.txt.jmc_relocate_unix_tarball(candidate, version, vendor, jmcBinaryExec(vendor, MacX64)))
+          case (Relocate, JMC, _, LinuxX32 | LinuxX64 | LinuxARM64 | LinuxARM32HF | LinuxARM32SF, _) =>
+            Ok(views.txt.jmc_relocate_unix_tarball(candidate, version, vendor, jmcBinaryExec(vendor, platform)))
+          case (Relocate, JMC, _, Windows64, _) =>
+            Ok(views.txt.jmc_relocate_win_zip(candidate, version, vendor, jmcBinaryExec(vendor, Windows64)))
+
           case (_, _, _, _, _) => NotFound
         }
       }

--- a/app/domain/domain.scala
+++ b/app/domain/domain.scala
@@ -71,6 +71,7 @@ object Hooks {
   def from(phase: String) = phase match {
     case Post.phase => Post
     case Pre.phase  => Pre
+    case Relocate.phase => Relocate
   }
 }
 case object Post extends Hooks {
@@ -78,4 +79,7 @@ case object Post extends Hooks {
 }
 case object Pre extends Hooks {
   override val phase = "pre"
+}
+case object Relocate extends Hooks {
+  override val phase = "relocate"
 }

--- a/app/views/java_relocate_osx_tarball.scala.txt
+++ b/app/views/java_relocate_osx_tarball.scala.txt
@@ -1,0 +1,25 @@
+@import domain._
+@(candidate: Candidate, version: String, platform: Platform)#!/bin/bash
+#Relocation Hook: osx-java
+function __sdkman_relocate_installation_hook {
+    __sdkman_echo_debug "A @{platform.name} relocation hook was found for @{candidate.name} @{version}-openjdk."
+
+    local present_dir="$(pwd)"
+    local candidate_dir="${SDKMAN_CANDIDATE_DIR}/@{candidate.name}/@{version}"
+    local work_jdk_dir="${SDKMAN_DIR}/tmp/@{candidate.name}-@{version}"
+
+    echo ""
+    __sdkman_echo_green "Relocating @{candidate.name} @version..."
+
+    #Move ./Contents/Home to temp location
+    cd "$candidate_dir"/*/Contents
+    mv -f Home "$work_jdk_dir"
+
+    #Replace candidate
+    cd "$present_dir"
+    rm -rf "$candidate_dir"
+    mv -f "$work_jdk_dir" "$candidate_dir"
+
+    echo ""
+    __sdkman_echo_green "Done relocating..."
+}

--- a/app/views/jmc_relocate_unix_tarball.scala.txt
+++ b/app/views/jmc_relocate_unix_tarball.scala.txt
@@ -1,0 +1,29 @@
+@import domain._
+@(candidate: Candidate, version: String, vendor: String, executableBinary: String)#!/bin/bash
+#Relocation Hook: unix-jmc-tarball
+function __sdkman_relocate_installation_hook {
+    __sdkman_echo_debug "A unix relocate hook was found for JMC @vendor @version."
+
+    local present_dir="$(pwd)"
+    local executable_binary="@{executableBinary}"
+    local candidate_dir="${SDKMAN_CANDIDATE_DIR}/@{candidate.name}/@{version}"
+
+    echo ""
+    __sdkman_echo_green "Relocating JMC @vendor @version..."
+
+    @if(vendor == "zulu") {
+      # deal with zulu folder structure
+      cd "$candidate_dir"/*
+    } else {
+      # deal with jmc flat structure
+      cd "$candidate_dir"
+    }
+
+    mkdir bin
+    cd bin
+    ln -s ../"${executable_binary}" jmc
+    cd "$present_dir"
+
+    echo ""
+    __sdkman_echo_green "Done relocating..."
+}

--- a/app/views/jmc_relocate_win_zip.scala.txt
+++ b/app/views/jmc_relocate_win_zip.scala.txt
@@ -1,0 +1,29 @@
+@import domain._
+@(candidate: Candidate, version: String, vendor: String, executableBinary: String)#!/bin/bash
+#Relocation Hook: win-jmc-zip
+function __sdkman_relocate_installation_hook {
+    __sdkman_echo_debug "A Windows relocate hook was found for JMC @vendor @version."
+
+    local present_dir="$(pwd)"
+    local executable_binary="@{executableBinary}"
+    local candidate_dir="${SDKMAN_CANDIDATE_DIR}/@{candidate.name}/@{version}"
+
+    echo ""
+    __sdkman_echo_green "Relocating JMC @vendor @version..."
+
+    @if(vendor == "zulu") {
+      # deal with zulu folder structure
+      cd "$candidate_dir"/*
+    } else {
+      # deal with jmc flat structure
+      cd "$candidate_dir"
+    }
+
+    mkdir bin
+    cd bin
+    ln -s ../"${executable_binary}" jmc
+    cd "$present_dir"
+
+    echo ""
+    __sdkman_echo_green "Done relocating..."
+}

--- a/features/relocate_hooks.feature
+++ b/features/relocate_hooks.feature
@@ -1,0 +1,23 @@
+Feature: Relocate Hooks
+
+  Scenario: A Relocate Hook request for java OSX served
+    When a hook is requested at /hooks/relocate/java/8.0.161-zulu/darwinx64
+    Then a 200 status code is received
+    And the response script contains "Relocation Hook: osx-java"
+
+  Scenario: A Relocate Hook request for java Linux is not served
+    When a hook is requested at /hooks/relocate/java/9.0.4-open/linuxx64
+    Then a 404 status code is received
+
+  Scenario Outline:
+    When a hook is requested at <uri>
+    Then a 200 status code is received
+    And the response script contains "<contains>"
+    Examples:
+      | uri                                            | contains                            |
+      | /hooks/relocate/jmc/8.0.0.17-zulu/linuxx64     | Relocation Hook: unix-jmc-tarball   |
+      | /hooks/relocate/jmc/8.0.0-adpt/linuxx64        | Relocation Hook: unix-jmc-tarball   |
+      | /hooks/relocate/jmc/8.0.0.17-zulu/darwinx64    | Relocation Hook: unix-jmc-tarball   |
+      | /hooks/relocate/jmc/8.0.0-adpt/darwinx64       | Relocation Hook: unix-jmc-tarball   |
+      | /hooks/relocate/jmc/8.0.0-adpt/cygwin          | Relocation Hook: win-jmc-zip        |
+      | /hooks/relocate/jmc/8.0.0-adpt/msys_nt-10.0    | Relocation Hook: win-jmc-zip        |


### PR DESCRIPTION
The idea is for sdkman-cli to skip the post-hooks after downloading the artifacts, perform the checksum, expand the archive  (unzip, tar), and move the files to its final destination (under `${SDKMAN_CANDIDATES_DIR}/${candidate}/${version}`).

These 'relocation' hooks will be executed at the very end of the pipeline, and will shuffle things around for a very small number of binaries (mainly JDK for OSX and JMC). 

This logic moves the logic from the  post hooks we have today to a later stage, so we can avoid re-packaging the artifacts (which breaks checksumming).