### PR TITLE
Add CI mode support to beta installation template

### DIFF
--- a/app/controllers/InstallController.scala
+++ b/app/controllers/InstallController.scala
@@ -19,7 +19,7 @@ class InstallController @Inject() (
 
   private val betaBaseUrlO = configUrl("service.betaBaseUrl")
 
-  def install(beta: Boolean, rcUpdate: Option[Boolean]) = Action.async { _ =>
+  def install(beta: Boolean, rcUpdate: Option[Boolean], ci: Option[Boolean]) = Action.async { _ =>
     appRepo.findApplication().map { maybeApp =>
       val response = for {
         stableBaseUrl <- stableBaseUrlO
@@ -37,7 +37,8 @@ class InstallController @Inject() (
               cliNativeVersion = betaNativeVersion,
               baseUrl = betaBaseUrl,
               rcUpdate = rcUpdate.getOrElse(true),
-              beta = true
+              beta = true,
+              ci = ci.getOrElse(false)
             )
           )
         } else {
@@ -47,7 +48,8 @@ class InstallController @Inject() (
               cliNativeVersion = stableNativeVersion,
               baseUrl = stableBaseUrl,
               rcUpdate = rcUpdate.getOrElse(true),
-              beta = false
+              beta = false,
+              ci = ci.getOrElse(false)
             )
           )
         }

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -1,4 +1,4 @@
-@(cliVersion: String, cliNativeVersion: String, baseUrl: String, rcUpdate: Boolean, beta: Boolean)#!/bin/bash
+@(cliVersion: String, cliNativeVersion: String, baseUrl: String, rcUpdate: Boolean, beta: Boolean, ci: Boolean)#!/bin/bash
 @includes.license()
 
 @includes.statusline("install", cliVersion, cliNativeVersion, baseUrl, beta)

--- a/app/views/install_beta.scala.txt
+++ b/app/views/install_beta.scala.txt
@@ -68,22 +68,35 @@ echo "$SDKMAN_PLATFORM" > "$sdkman_platform_file"
 
 echo "Prime the config file..."
 touch "$sdkman_config_file"
+
+@if(ci) {
+# CI mode - optimized for automated environments
+echo "sdkman_auto_answer=true" >> "$sdkman_config_file"
+echo "sdkman_colour_enable=false" >> "$sdkman_config_file"
+echo "sdkman_selfupdate_feature=false" >> "$sdkman_config_file"
+} else {
+# Interactive mode - optimized for human use
 echo "sdkman_auto_answer=false" >> "$sdkman_config_file"
+echo "sdkman_colour_enable=true" >> "$sdkman_config_file"
+echo "sdkman_selfupdate_feature=true" >> "$sdkman_config_file"
+}
+
+# Set shell-specific config
 if [ -z "$ZSH_VERSION" -a -z "$BASH_VERSION" ]; then
     echo "sdkman_auto_complete=false" >> "$sdkman_config_file"
 else
     echo "sdkman_auto_complete=true" >> "$sdkman_config_file"
 fi
+
+# Common settings that don't change based on CI mode
 echo "sdkman_auto_env=false" >> "$sdkman_config_file"
 echo "sdkman_beta_channel=@beta" >> "$sdkman_config_file"
 echo "sdkman_checksum_enable=true" >> "$sdkman_config_file"
-echo "sdkman_colour_enable=true" >> "$sdkman_config_file"
 echo "sdkman_curl_connect_timeout=7" >> "$sdkman_config_file"
 echo "sdkman_curl_max_time=10" >> "$sdkman_config_file"
 echo "sdkman_debug_mode=false" >> "$sdkman_config_file"
 echo "sdkman_insecure_ssl=false" >> "$sdkman_config_file"
 echo "sdkman_native_enable=true" >> "$sdkman_config_file"
-echo "sdkman_selfupdate_feature=true" >> "$sdkman_config_file"
 
 # script cli distribution
 echo "Installing script cli archive..."

--- a/app/views/install_stable.scala.txt
+++ b/app/views/install_stable.scala.txt
@@ -1,4 +1,4 @@
-@(cliVersion: String, cliNativeVersion: String, baseUrl: String, rcUpdate: Boolean, beta: Boolean)#!/bin/bash
+@(cliVersion: String, cliNativeVersion: String, baseUrl: String, rcUpdate: Boolean, beta: Boolean, ci: Boolean)#!/bin/bash
 @includes.license()
 
 @includes.statusline("install", cliVersion, cliNativeVersion, baseUrl, beta)

--- a/conf/routes
+++ b/conf/routes
@@ -3,8 +3,8 @@
 # ~~~~
 
 GET        /alive                                             controllers.HealthController.alive
-GET        /install/beta                                      controllers.InstallController.install(beta: Boolean = true, rcupdate: Option[Boolean])
-GET        /install/stable                                    controllers.InstallController.install(beta: Boolean = false, rcupdate: Option[Boolean])
+GET        /install/beta                                      controllers.InstallController.install(beta: Boolean = true, rcupdate: Option[Boolean], ci: Option[Boolean])
+GET        /install/stable                                    controllers.InstallController.install(beta: Boolean = false, rcupdate: Option[Boolean], ci: Option[Boolean])
 GET        /selfupdate/beta/:platform                         controllers.SelfUpdateController.selfUpdate(beta: Boolean = true, platform)
 GET        /selfupdate/beta                                   controllers.SelfUpdateController.selfUpdate(beta: Boolean = true, platform = "unknown")
 GET        /selfupdate/stable/:platform                       controllers.SelfUpdateController.selfUpdate(beta: Boolean ?= false, platform)

--- a/features/installation.feature
+++ b/features/installation.feature
@@ -55,4 +55,16 @@ Feature: Installation
     And a "text/plain; charset=UTF-8" content type is received
     And the response script contains "# install:- channel: beta"
     And the response script contains "Attempt update of interactive bash profile "
-    And the response script contains "Attempt update of zsh profile...""
+    And the response script contains "Attempt update of zsh profile..."
+    
+  Scenario: Install SDKMAN beta in CI mode
+    When a request is made to the /install/beta?ci=true endpoint
+    Then a 200 status code is received
+    And a "text/plain; charset=UTF-8" content type is received
+    And the response script contains "# install:- channel: beta"
+    And the response script contains "sdkman_auto_answer=true"
+    And the response script contains "sdkman_colour_enable=false"
+    And the response script contains "sdkman_selfupdate_feature=false"
+    And the response script does not contain "sdkman_auto_answer=false"
+    And the response script does not contain "sdkman_colour_enable=true"
+    And the response script does not contain "sdkman_selfupdate_feature=true"

--- a/test/steps/Steps.scala
+++ b/test/steps/Steps.scala
@@ -26,11 +26,16 @@ class Steps extends ScalaDsl with EN with Matchers {
   And("""^the stable native CLI Version is "(.*)"""") { native: String =>
     stableNativeCliVersion = native
   }
-  
+
   And("""^the beta native CLI Version is "(.*)"""") { native: String =>
     betaNativeCliVersion = native
     // Insert all CLI versions after both stable and beta native CLI versions are set
-    Mongo.insertCliVersions(stableCliVersion, betaCliVersion, stableNativeCliVersion, betaNativeCliVersion)
+    Mongo.insertCliVersions(
+      stableCliVersion,
+      betaCliVersion,
+      stableNativeCliVersion,
+      betaNativeCliVersion
+    )
   }
 
   And("""^a request is made to the (.*) endpoint$""") { endpoint: String =>

--- a/test/steps/support/Mongo.scala
+++ b/test/steps/support/Mongo.scala
@@ -38,7 +38,15 @@ object Mongo {
       betaNativeCliVersion: String
   ): Seq[Completed] =
     appCollection
-      .insertOne(Application("OK", stableCliVersion, betaCliVersion, stableNativeCliVersion, betaNativeCliVersion))
+      .insertOne(
+        Application(
+          "OK",
+          stableCliVersion,
+          betaCliVersion,
+          stableNativeCliVersion,
+          betaNativeCliVersion
+        )
+      )
       .results()
 
   def dropAppCollection(): Seq[Completed] = appCollection.drop().results()

--- a/test/steps/support/World.scala
+++ b/test/steps/support/World.scala
@@ -15,6 +15,6 @@ object World {
   var betaCliVersion = ""
 
   var stableNativeCliVersion = ""
-  
+
   var betaNativeCliVersion = ""
 }


### PR DESCRIPTION
## Summary
- Implements the `ci=true` query parameter for beta installation scripts to optimize SDKMAN settings for CI environments
- Configures non-interactive settings when running in CI mode: `sdkman_auto_answer=true`, `sdkman_colour_enable=false`, and `sdkman_selfupdate_feature=false`
- Adds tests to verify the CI mode functionality with both positive and negative assertions

## Test plan
- Cucumber tests verify the installation script correctly configures CI-friendly settings when the `ci=true` parameter is present
- All tests pass for existing and new functionality

This addresses part of issue sdkman/sdkman-cli#1270  in the sdkman-cli repository.

🤖 Generated with [Claude Code](https://claude.ai/code)