### PR TITLE
feat: add RISC-V 64-bit (riscv64) platform support

### DIFF
--- a/app/domain/domain.scala
+++ b/app/domain/domain.scala
@@ -24,6 +24,7 @@ object Platform {
     case "linuxarm64"   => LinuxARM64
     case "linuxarm32sf" => LinuxARM32SF
     case "linuxarm32hf" => LinuxARM32HF
+    case "linuxriscv64" => LinuxRISCV64
     case "darwinx64"    => MacX64
     case "darwinarm64"  => MacARM64
     case "windowsx64"   => Windows64
@@ -44,6 +45,7 @@ object Platform {
   val LinuxARM32SF = Platform("LINUX_ARM32SF", "Linux ARM 32bit Soft Float")
   val LinuxARM32HF = Platform("LINUX_ARM32HF", "Linux ARM 32bit Hard Float")
   val LinuxARM64   = Platform("LINUX_ARM64", "Linux ARM 64bit", Some("aarch64-unknown-linux-gnu"))
+  val LinuxRISCV64 = Platform("LINUX_RISCV64", "Linux RISC-V 64bit", Some("riscv64gc-unknown-linux-gnu"))
   val MacX64       = Platform("MAC_OSX", "macOS 64bit", Some("x86_64-apple-darwin"))
   val MacARM64     = Platform("MAC_ARM64", "macOS ARM 64bit", Some("aarch64-apple-darwin"))
   val Windows64    = Platform("WINDOWS_64", "Cygwin", Some("x86_64-pc-windows-msvc"))


### PR DESCRIPTION
## Summary

- Add `LinuxRISCV64` platform val with distribution `"LINUX_RISCV64"`, name `"Linux RISC-V 64bit"`, and triple `"riscv64gc-unknown-linux-gnu"`
- Add case match for `"linuxriscv64"` platform identifier

Closes #65

## Related

- sdkman/sdkman-cli#1496, sdkman/sdkman-cli-native#375, sdkman/sdkman-disco-integration#46, sdkman/vendor-release#17, sdkman/sdkman-broker-2#10