### PR TITLE
fix OSX post java tarball Contents dir glob

### DIFF
--- a/app/views/java_post_osx_tarball.scala.txt
+++ b/app/views/java_post_osx_tarball.scala.txt
@@ -16,7 +16,7 @@ function __sdkman_post_installation_hook {
     mkdir -p "$work_dir"
     /usr/bin/env tar zxf "$binary_input" -C "$work_dir"
 
-    cd "$work_dir"/*/Contents
+    cd "$work_dir"/**/Contents
     mv -f Home "$work_jdk_dir"
     cd "${SDKMAN_DIR}"/tmp
     /usr/bin/env zip -qyr "$zip_output" "@{candidate.name}-@{version}"


### PR DESCRIPTION
## Summary
At least some tarballs now contains 2 levels of directories instead of 1, which breaks the glob matching.
e.g. `/zulu8.54.0.21-ca-jdk8.0.292-macosx_aarch64/zulu-8.jdk` for `sdk install java 8.0.292-zulu`
The problem is also present for other java versions like `11.0.25-zulu`, `17.0.13-zulu` or `21.0.5-zulu`.

The tarball internal directory tree might have changed recently and the post-download hook haven't been modified.

## Log output
```bash
% set -x ; sdk install java 8.0.292-zulu
# ...
# Truncated output
# ...
+__sdkman_post_installation_hook:10> __sdkman_echo_green 'Repackaging Java 8.0.292-zulu...'
+__sdkman_echo_green:1> __sdkman_echo 32m 'Repackaging Java 8.0.292-zulu...'
+__sdkman_echo:1> [[ true == false ]]
+__sdkman_echo:4> echo -e '\033[1;32mRepackaging Java 8.0.292-zulu...\033[0m'
Repackaging Java 8.0.292-zulu...
+__sdkman_post_installation_hook:12> mkdir -p /Users/l.gatellier/devtools/sdkman/tmp/out
+__sdkman_post_installation_hook:13> /usr/bin/env tar zxf /Users/l.gatellier/devtools/sdkman/tmp/java-8.0.292-zulu.bin -C /Users/l.gatellier/devtools/sdkman/tmp/out
__sdkman_post_installation_hook:15: no matches found: /Users/l.gatellier/devtools/sdkman/tmp/out/*/Contents
```
```bash
 % find tmp -name Contents
tmp/out/zulu8.54.0.21-ca-jdk8.0.292-macosx_aarch64/zulu-8.jdk/Contents
```